### PR TITLE
enable ios simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # react-native-helios
 
+> ⚠️ Currently `react-native-helios` only supports execution on iOS devices and simulators.
+
 Throughout the majority of [__Ethereum__](https://ethereum.org/en/)'s history, frontend applications have been forced to rely upon centralized interfaces like [__Infura__](https://www.infura.io/) to access the decentralized network. This is because to be a meaningful participant in the decentralized network, like an entity capable of submitting transactions or maintaining a verifiable history the network state, the protocol's current design [__demands high device specifications__](https://www.youtube.com/watch?v=0stc9jnQLXA) that are insurmountable for even high-end mobile devices.
 
-This reliance on third party ethereum providers is useful for developers, but are subject to the downfalls of all centralized systems; susceptibility to downtime, subservience to censorship and financialization.
+This reliance on third party ethereum providers is useful for developers, but are subject to the downfalls of all centralized systems; susceptibility to downtime and subservience to censorship and financialization.
 
 > ⚠️ __Decentralization is incredibly important!__
 >
->At the time of writing, [__DeFi__](https://ethereum.org/en/defi) frontends are threatend into enforcing censorship on honest users, miners are incentivised to censor global transactions in compliance with the US-based [__OFAC__](https://youtu.be/Ytaa_5liwMA?t=3659), and the relative ease of centralized interfaces compared to truly decentralized equivalents lure users into [__extreme losses due to excessive trust__](https://twitter.com/JG_Nuke/status/1591070331988774913).
+> At the time of writing, [__DeFi__](https://ethereum.org/en/defi) frontends are threatened into enforcing censorship upon honest users, miners are incentivised to censor global transactions in compliance with the US-based [__OFAC__](https://youtu.be/Ytaa_5liwMA?t=3659), and the relative ease of centralized interfaces compared to truly decentralized equivalents lure users into [__extreme losses due to excessive trust__](https://twitter.com/JG_Nuke/status/1591070331988774913).
 >
-> The decentralized future is __inclusive of every human__, is __objective__ and __credibly neutral__. Smart contracts can enforce self-regulation, and the natural properties of mathematics [__should be applied for public good__](https://www.coindesk.com/layer2/2022/08/09/what-the-tornado-cash-sanction-means-for-privacy-coins/).
+> The decentralized future is __inclusive of every human__, __objective__ and __credibly neutral__.
 
 ## Introducing [`helios`](https://github.com/a16z/helios)! 👋
 
@@ -63,9 +65,7 @@ console.log(
 
 ## Building from source 🏗
 
-> __Note__ Right now we only support building via MacOS. More platforms will be supported in future!
->
-> ⚠️ Currently `react-native-helios` only supports execution on a physical device. It will __not__ compile on the iOS simulator.
+> __Note__ Currently we only support compiling on __Apple Silicon__-based Macs.
 
 1. Make sure you've installed [`rustup`](https://www.rust-lang.org/tools/install):
 
@@ -81,7 +81,7 @@ cd react-native-helios
 yarn && yarn heliosup
 ```
 
-Once this task has completed, the rust library dependencies will be compiled for iOS using [`cargo-lipo`](https://github.com/TimNN/cargo-lipo), a runtime-compatible bridge interface for the generated binaries will be exported by [`swift-bridge`](https://github.com/chinedufn/swift-bridge), and the [`example/`](./example) project's [__pods__](https://cocoapods.org/) directory will be populated with the new library binaries.
+Once this task has completed, the rust library dependencies will be compiled for iOS using [`cargo-lipo`](https://github.com/TimNN/cargo-lipo), a runtime-compatible bridge interface for the generated binaries will be exported by [`swift-bridge`](https://github.com/chinedufn/swift-bridge), and the [`example/`](./example) project's [__pods__](https://cocoapods.org/) directory will be populated with the new library binaries. To support the `arm64` architecture for both simulated and physical iOS devices, the target-specific static libraries are repackaged into an [`XCFramework`](https://medium.com/trueengineering/xcode-and-xcframeworks-new-format-of-packing-frameworks-ca15db2381d3).
 
 3. Finally, open up the [`example .xcworkspace`](./example/ios) and hit play ▶.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```shell
 git clone https://github.com/cawfree/react-native-helios
 cd react-native-helios
-yarn heliosup
+yarn && yarn heliosup
 ```
 
 Once this task has completed, the rust library dependencies will be compiled for iOS using [`cargo-lipo`](https://github.com/TimNN/cargo-lipo), a runtime-compatible bridge interface for the generated binaries will be exported by [`swift-bridge`](https://github.com/chinedufn/swift-bridge), and the [`example/`](./example) project's [__pods__](https://cocoapods.org/) directory will be populated with the new library binaries.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This reliance on third party ethereum providers is useful for developers, but ar
 
 ## Introducing [`helios`](https://github.com/a16z/helios)! 👋
 
-[__Helios__](https://github.com/a16z/helios) is an innovative new [__light client__](https://ethereum.org/en/developers/docs/nodes-and-clients/) for Ethereum which is minimal enough to run on mobile devices or even from within [__React Native__](https://reactnative.dev) applications. 
+[__Helios__](https://github.com/a16z/helios) is an innovative new [__light client__](https://ethereum.org/en/developers/docs/nodes-and-clients/) for Ethereum which is minimal enough to run on mobile devices or even from within [__React Native__](https://reactnative.dev) applications.
 
 The key property enabled by `helios`, compared to traditional light clients, is the level of trustlessness.
 
@@ -78,7 +78,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```shell
 git clone https://github.com/cawfree/react-native-helios
 cd react-native-helios
-yarn && yarn heliosup
+yarn heliosup
 ```
 
 Once this task has completed, the rust library dependencies will be compiled for iOS using [`cargo-lipo`](https://github.com/TimNN/cargo-lipo), a runtime-compatible bridge interface for the generated binaries will be exported by [`swift-bridge`](https://github.com/chinedufn/swift-bridge), and the [`example/`](./example) project's [__pods__](https://cocoapods.org/) directory will be populated with the new library binaries.

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -302,7 +302,7 @@ PODS:
   - React-jsinspector (0.70.6)
   - React-logger (0.70.6):
     - glog
-  - react-native-helios (0.1.0):
+  - react-native-helios (0.1.2):
     - React
   - React-perflogger (0.70.6)
   - React-RCTActionSheet (0.70.6):
@@ -562,7 +562,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: b4a65947391c658450151275aa406f2b8263178f
   React-jsinspector: 60769e5a0a6d4b32294a2456077f59d0266f9a8b
   React-logger: 1623c216abaa88974afce404dc8f479406bbc3a0
-  react-native-helios: 33760d6b4d93b588a3c886e3e872980dcca95e4f
+  react-native-helios: 62debd1892f4477c7de1afc69f3723884730fbd8
   React-perflogger: 8c79399b0500a30ee8152d0f9f11beae7fc36595
   React-RCTActionSheet: 7316773acabb374642b926c19aef1c115df5c466
   React-RCTAnimation: 5341e288375451297057391227f691d9b2326c3d

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -562,7 +562,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: b4a65947391c658450151275aa406f2b8263178f
   React-jsinspector: 60769e5a0a6d4b32294a2456077f59d0266f9a8b
   React-logger: 1623c216abaa88974afce404dc8f479406bbc3a0
-  react-native-helios: 62debd1892f4477c7de1afc69f3723884730fbd8
+  react-native-helios: 665f06f7c87fc3c1344b52cdb3e2ee6b1e710217
   React-perflogger: 8c79399b0500a30ee8152d0f9f11beae7fc36595
   React-RCTActionSheet: 7316773acabb374642b926c19aef1c115df5c466
   React-RCTAnimation: 5341e288375451297057391227f691d9b2326c3d

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3756,7 +3756,7 @@ react-native-gradle-plugin@^0.70.3:
   integrity sha512-oOanj84fJEXUg9FoEAQomA8ISG+DVIrTZ3qF7m69VQUJyOGYyDZmPqKcjvRku4KXlEH6hWO9i4ACLzNBh8gC0A==
 
 react-native-helios@../:
-  version "0.1.0"
+  version "0.1.2"
 
 react-native@0.70.6:
   version "0.70.6"

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1782,9 +1782,9 @@ ci-info@^2.0.0:
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
 ci-info@^3.2.0:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.6.1.tgz#7594f1c95cb7fdfddee7af95a13af7dbc67afdcf"
-  integrity sha512-up5ggbaDqOqJ4UqLKZ2naVkyqSJQgJi5lwD6b6mM748ysrghDBX0bx/qJTUHzw7zu6Mq4gycviSF5hJnwceD8w==
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.6.2.tgz#362ea15378f1c39378ba786affbc1c9ef015ecfd"
+  integrity sha512-lVZdhvbEudris15CLytp2u6Y0p5EKfztae9Fqa189MfNmln9F33XuH69v5fvNfiRN5/0eAUz2yJL3mo+nhaRKg==
 
 class-utils@^0.3.5:
   version "0.3.6"

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1438,9 +1438,9 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
     color-convert "^2.0.1"
 
 anymatch@^3.0.3:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
-  integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
+  integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
@@ -1755,9 +1755,9 @@ camelcase@^6.0.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001400:
-  version "1.0.30001431"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz#e7c59bd1bc518fae03a4656be442ce6c4887a795"
-  integrity sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==
+  version "1.0.30001434"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz#ec1ec1cfb0a93a34a0600d37903853030520a4e5"
+  integrity sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==
 
 chalk@^2.0.0:
   version "2.4.2"

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -1,3 +1,4 @@
 libhelios.a
 libhelios.h
+libhelios.xcframework/
 SwiftBridgeCore.swift

--- a/react-native-helios.podspec
+++ b/react-native-helios.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => "9.0" }
   s.source       = { :git => "https://github.com/cawfree/react-native-helios.git", :tag => "#{s.version}" }
 
-  s.vendored_libraries = 'ios/libhelios.a'
+  s.vendored_frameworks = 'ios/libhelios.xcframework'
   s.source_files = "ios/**/*.{h,c,m,swift}"
   s.requires_arc = true
 

--- a/scripts/heliosup.ts
+++ b/scripts/heliosup.ts
@@ -167,7 +167,7 @@ fs.writeFileSync(
     'THISDIR=$(dirname $0)',
     'cd $THISDIR',
     'export SWIFT_BRIDGE_OUT_DIR="$(pwd)/generated"',
-    'cargo lipo --release',
+    `cargo lipo --release --targets ${APPLE_TARGETS[rust_version].join(',')}`,
   ].join('\n')
 );
 

--- a/scripts/heliosup.ts
+++ b/scripts/heliosup.ts
@@ -168,7 +168,8 @@ fs.writeFileSync(
     'cd $THISDIR',
     'export SWIFT_BRIDGE_OUT_DIR="$(pwd)/generated"',
     '',
-    `cargo lipo --release --targets ${APPLE_TARGETS[rust_version].join(',')}`,
+    //`cargo lipo --release --targets ${APPLE_TARGETS[rust_version].join(',')}`,
+    'cargo build --target aarch64-apple-ios-sim',
   ].join('\n')
 );
 
@@ -183,6 +184,17 @@ fs.writeFileSync(
       .readFileSync(toml, 'utf-8')
       .split('\n')
       .flatMap((str) => {
+        if (str === '[patch.crates-io]') {
+          return [
+            str,
+            //'openssl-src = { version = "300", optional = true }',
+            //'openssl-src = { git = "https://github.com/sfackler/rust-openssl", version = "=300.0.11+3.0.7", optional = true }',
+            //'openssl-sys = { git = "https://github.com/ncitron/ethers-rs", branch = "fix-retry" }',
+          ];
+        }
+
+        //'openssl-src = { version = "300" }',
+
         if (str === '[dependencies]') {
           return [
             '[build-dependencies]',
@@ -190,7 +202,7 @@ fs.writeFileSync(
             '',
             str,
             'swift-bridge = {version = "0.1", features = ["async"]}',
-
+            '',
             // TODO: Check these are still required?
             'futures = "0.3.23"',
             'eyre = "0.6.8"',

--- a/scripts/heliosup.ts
+++ b/scripts/heliosup.ts
@@ -167,6 +167,7 @@ fs.writeFileSync(
     'THISDIR=$(dirname $0)',
     'cd $THISDIR',
     'export SWIFT_BRIDGE_OUT_DIR="$(pwd)/generated"',
+    '',
     `cargo lipo --release --targets ${APPLE_TARGETS[rust_version].join(',')}`,
   ].join('\n')
 );

--- a/scripts/heliosup.ts
+++ b/scripts/heliosup.ts
@@ -171,8 +171,11 @@ fs.writeFileSync(
     'cd $THISDIR',
     'export SWIFT_BRIDGE_OUT_DIR="$(pwd)/generated"',
     '',
-    //`cargo lipo --release --targets ${APPLE_TARGETS[rust_version].join(',')}`,
-    'cargo build --target aarch64-apple-ios-sim',
+
+    // https://gist.github.com/surpher/bbf88e191e9d1f01ab2e2bbb85f9b528#universal-ios-arm64-mobile-device--x86_64-simulator
+    'cargo lipo --release',
+    // https://gist.github.com/surpher/bbf88e191e9d1f01ab2e2bbb85f9b528#ios-simulator-arm64
+    'cargo build -Z build-std --target aarch64-apple-ios-sim --release',
   ].join('\n')
 );
 

--- a/scripts/heliosup.ts
+++ b/scripts/heliosup.ts
@@ -22,7 +22,11 @@ const APPLE_TARGETS: Record<string, readonly string[]> = {
     'x86_64-apple-ios',
     'i386-apple-ios',
   ],
-  [RUST_VERSION_LATEST]: ['aarch64-apple-ios', 'x86_64-apple-ios'],
+  [RUST_VERSION_LATEST]: [
+    'aarch64-apple-ios',
+    'x86_64-apple-ios',
+    'aarch64-apple-ios-sim',
+  ],
 };
 
 const rust_version = RUST_VERSION_LATEST;
@@ -115,15 +119,12 @@ fs.writeFileSync(
     '    client.start().await.unwrap();',
     '',
     '    self.client = Some(client);',
-    '    println!("did allocate client!");',
     '  }',
     '',
     '  async fn helios_get_block_number(&mut self) -> String {',
     '    if let Some(client) = &self.client {',
-    '      println!("client is valid in get_block_number");',
     '      return client.get_block_number().await.unwrap().to_string();',
     '    }',
-    '    println!("client is not valid in get_block_number");',
     '    return (-1).to_string();',
     '  }',
     '',

--- a/scripts/heliosup.ts
+++ b/scripts/heliosup.ts
@@ -299,10 +299,20 @@ fs.writeFileSync(header, result_h);
 
 const ios = path.resolve('ios');
 
+// Physical
+//const staticLib = path.resolve(
+//  helios,
+//  'target',
+//  'universal',
+//  'release',
+//  `lib${name}.a`
+//);
+
+// Simulator
 const staticLib = path.resolve(
   helios,
   'target',
-  'universal',
+  'aarch64-apple-ios-sim',
   'release',
   `lib${name}.a`
 );


### PR DESCRIPTION
#### Introduce support for running `react-native-helios` on the iOS simulator (`arm64`)! 🎉

- Manually replace `helios`' Rust dependency on [`openssl-sys`](https://crates.io/crates/openssl-sys) in order to enable compilation on simulated architecture.
  - Achieve dependency overriding via `patch-crates.io` declaration in root `Cargo.toml`, which reconfigures our `openssl-sys` imports to target at a local clone of [`rust-openssl`](https://github.com/sfackler/rust-openssl) versioned against `b30313a9775ed861ce9456745952e3012e5602ea`.
- Fixed typo's and instructions in README.md.
- Export multiple `libhelios.a` targets (`aarch64-apple-ios` and `aarch64-apple-ios-sim`) to an `.xcworkspace` to prevent  conflicts in target architecture when trying to create a fat file using `cargo-lipo`.