### PR TITLE
Add goerli support

### DIFF
--- a/android/src/main/java/com/helios/HeliosModule.java
+++ b/android/src/main/java/com/helios/HeliosModule.java
@@ -47,7 +47,7 @@ public class HeliosModule extends ReactContextBaseJavaModule {
         params.getString("untrusted_rpc_url"),
         params.getString("consensus_rpc_url"),
         params.getDouble("rpc_port"),
-        params.getString("network"),
+        params.getString("network")
       );
       promise.resolve("");
     } });

--- a/android/src/main/java/com/helios/HeliosModule.java
+++ b/android/src/main/java/com/helios/HeliosModule.java
@@ -46,7 +46,8 @@ public class HeliosModule extends ReactContextBaseJavaModule {
       helios.heliosStart(
         params.getString("untrusted_rpc_url"),
         params.getString("consensus_rpc_url"),
-        params.getDouble("rpc_port")
+        params.getDouble("rpc_port"),
+        params.getString("network"),
       );
       promise.resolve("");
     } });

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -302,7 +302,7 @@ PODS:
   - React-jsinspector (0.70.6)
   - React-logger (0.70.6):
     - glog
-  - react-native-helios (0.1.5):
+  - react-native-helios (0.1.6):
     - React
   - React-perflogger (0.70.6)
   - React-RCTActionSheet (0.70.6):
@@ -562,7 +562,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: b4a65947391c658450151275aa406f2b8263178f
   React-jsinspector: 60769e5a0a6d4b32294a2456077f59d0266f9a8b
   React-logger: 1623c216abaa88974afce404dc8f479406bbc3a0
-  react-native-helios: f5d863bd56cb95a50ccbf65b545ffb66cfb6f345
+  react-native-helios: c5f7733d8bc777b24051ece9cd4a82bfbd853c95
   React-perflogger: 8c79399b0500a30ee8152d0f9f11beae7fc36595
   React-RCTActionSheet: 7316773acabb374642b926c19aef1c115df5c466
   React-RCTAnimation: 5341e288375451297057391227f691d9b2326c3d

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 
 import { Image, Platform, StyleSheet, Text, View } from 'react-native';
-import { start } from 'react-native-helios';
+import { Network, start } from 'react-native-helios';
 import { ethers } from 'ethers';
 
+const network: Network = Network.MAINNET;
 const rpc_port = 8545;
 
 const url = `http://${
@@ -16,6 +17,7 @@ export default function App() {
       void (async () => {
         try {
           await start({
+            network,
             rpc_port,
             // If you encounter any errors, please try creating your own Alchemy key.
             untrusted_rpc_url:

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,8 +1,26 @@
 import * as React from 'react';
 
 import { Image, Platform, StyleSheet, Text, View } from 'react-native';
-import { Network, start } from 'react-native-helios';
+import { Network, start, StartParams } from 'react-native-helios';
 import { ethers } from 'ethers';
+
+const ENVIRONMENTS: {
+  readonly [key in Network]: Pick<
+    StartParams,
+    'untrusted_rpc_url' | 'consensus_rpc_url'
+  >;
+} = {
+  [Network.MAINNET]: {
+    consensus_rpc_url: 'https://www.lightclientdata.org',
+    untrusted_rpc_url:
+      'https://eth-mainnet.g.alchemy.com/v2/pPwfAKdQqDr1OP-z5Txzmlk0YE1UvAQT',
+  },
+  [Network.GOERLI]: {
+    consensus_rpc_url: 'http://testing.prater.beacon-api.nimbus.team',
+    untrusted_rpc_url:
+      'https://eth-goerli.g.alchemy.com/v2/LyCUMBtAaTf03kVgcjPvW22KkwuKigZY',
+  },
+};
 
 const network: Network = Network.MAINNET;
 const rpc_port = 8545;
@@ -17,13 +35,9 @@ export default function App() {
       void (async () => {
         try {
           await start({
+            ...ENVIRONMENTS[network],
             network,
             rpc_port,
-            // If you encounter any errors, please try creating your own Alchemy key.
-            untrusted_rpc_url:
-              // https://github.com/scaffold-eth/scaffold-eth/blob/db24f28d1121468a08e7eed9affee43b0987aa10/packages/react-app/src/constants.js#L10
-              'https://eth-mainnet.g.alchemy.com/v2/oKxs-03sij-U_N0iOlrSsZFr29-IqbuF',
-            consensus_rpc_url: 'https://www.lightclientdata.org',
           });
 
           const provider = await ethers.providers.getDefaultProvider(url);

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3756,7 +3756,7 @@ react-native-gradle-plugin@^0.70.3:
   integrity sha512-oOanj84fJEXUg9FoEAQomA8ISG+DVIrTZ3qF7m69VQUJyOGYyDZmPqKcjvRku4KXlEH6hWO9i4ACLzNBh8gC0A==
 
 react-native-helios@../:
-  version "0.1.5"
+  version "0.1.6"
 
 react-native@0.70.6:
   version "0.70.6"

--- a/ios/Helios.swift
+++ b/ios/Helios.swift
@@ -16,6 +16,7 @@ class Helios: NSObject {
           let untrusted_rpc_url = params["untrusted_rpc_url"];
           let consensus_rpc_url = params["consensus_rpc_url"];
           let rpc_port = params["rpc_port"];
+          let network = params["network"];
 
           RUST_APPS["default"] = rustApp;
 
@@ -23,7 +24,8 @@ class Helios: NSObject {
               await rustApp.helios_start(
                 (untrusted_rpc_url as! String),
                 (consensus_rpc_url as! String),
-                (rpc_port as! Double)
+                (rpc_port as! Double),
+                (network as! String),
               );
               resolve("");
           }

--- a/ios/Helios.swift
+++ b/ios/Helios.swift
@@ -25,7 +25,7 @@ class Helios: NSObject {
                 (untrusted_rpc_url as! String),
                 (consensus_rpc_url as! String),
                 (rpc_port as! Double),
-                (network as! String),
+                (network as! String)
               );
               resolve("");
           }

--- a/scripts/heliosup.ts
+++ b/scripts/heliosup.ts
@@ -30,6 +30,14 @@ const arm64_v8a = path.resolve(libs, 'arm64-v8a');
 //const x86 = path.resolve(libs, 'x86');
 const x86_64 = path.resolve(libs, 'x86_64');
 
+const getSelectedNetwork = () => [
+  '  let selectedNetwork = match network {',
+  '    "MAINNET" => networks::Network::MAINNET,',
+  '    "GOERLI" => networks::Network::GOERLI,',
+  '    _ => panic!("Unknown network!"),',
+  '  },',
+];
+
 abstract class HeliosFactory {
   private static prepareBuildDir(): void {
     fs.existsSync(build) && fs.rmSync(build, { recursive: true });
@@ -194,7 +202,13 @@ class AppleHeliosFactory extends HeliosFactory {
       '    #[swift_bridge(init)]',
       '    fn new() -> RustApp;',
       '',
-      '    async fn helios_start(&mut self, untrusted_rpc_url: String, consensus_rpc_url: String, rpc_port: f64);',
+      '    async fn helios_start(',
+      '      &mut self,',
+      '      untrusted_rpc_url: String,',
+      '      consensus_rpc_url: String,',
+      '      rpc_port: f64,',
+      '      network: String,',
+      ');',
       '  }',
       '}',
       '',
@@ -211,9 +225,11 @@ class AppleHeliosFactory extends HeliosFactory {
       '    untrusted_rpc_url: String,',
       '    consensus_rpc_url: String,',
       '    rpc_port: f64,',
+      '    network: String,',
       '  ) {',
+      ...getSelectedNetwork(),
       '    let mut client = ClientBuilder::new()',
-      '      .network(networks::Network::MAINNET)',
+      '      .network(selectedNetwork)',
       '      .execution_rpc(&untrusted_rpc_url)',
       '      .consensus_rpc(&consensus_rpc_url)',
       '      .rpc_port((rpc_port as i16).try_into().unwrap())',
@@ -527,10 +543,12 @@ class AndroidHeliosFactory extends HeliosFactory {
       '    untrusted_rpc_url: String,',
       '    consensus_rpc_url: String,',
       '    rpc_port: f64,',
+      '    network: String,',
       '  ) {',
+      ...getSelectedNetwork(),
       '    self.runtime.block_on(async {',
       '      let mut client = ClientBuilder::new()',
-      '        .network(networks::Network::MAINNET)',
+      '        .network(selectedNetwork)',
       '        .consensus_rpc(&consensus_rpc_url)',
       '        .execution_rpc(&untrusted_rpc_url)',
       '        .rpc_port((rpc_port as i16).try_into().unwrap())',

--- a/scripts/heliosup.ts
+++ b/scripts/heliosup.ts
@@ -31,11 +31,11 @@ const arm64_v8a = path.resolve(libs, 'arm64-v8a');
 const x86_64 = path.resolve(libs, 'x86_64');
 
 const getSelectedNetwork = () => [
-  '  let selectedNetwork = match network {',
-  '    "MAINNET" => networks::Network::MAINNET,',
-  '    "GOERLI" => networks::Network::GOERLI,',
-  '    _ => panic!("Unknown network!"),',
-  '  },',
+  '    let selectedNetwork = match network.as_str() {',
+  '      "MAINNET" => networks::Network::MAINNET,',
+  '      "GOERLI" => networks::Network::GOERLI,',
+  '      _ => panic!("Unknown network!"),',
+  '    };',
 ];
 
 abstract class HeliosFactory {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,16 +17,25 @@ const Helios = NativeModules.Helios
       }
     );
 
+export enum Network {
+  MAINNET = 'MAINNET',
+  GOERLI = 'GOERLI',
+}
+
 export type StartParams = {
+  readonly network?: Network;
   readonly rpc_port?: number;
   readonly untrusted_rpc_url: string;
   readonly consensus_rpc_url: string;
 };
 
 export function start({
+  network: maybeNetwork,
   rpc_port: maybeRpcPort,
   ...extras
 }: StartParams): Promise<void> {
+  const network =
+    typeof maybeNetwork === 'string' ? maybeNetwork : Network.MAINNET;
   const rpc_port = typeof maybeRpcPort === 'number' ? maybeRpcPort : 8545;
-  return Helios.start({ ...extras, rpc_port });
+  return Helios.start({ ...extras, rpc_port, network });
 }


### PR DESCRIPTION
- Adds a `network` parameter to `start()`.
- Allows caller to define whether to use `MAINNET` or `GOERLI`.
- Updated example app to include a set of default Alchemy keys to experiment with both.