### PR TITLE
Upgrade to latest

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -302,7 +302,7 @@ PODS:
   - React-jsinspector (0.70.6)
   - React-logger (0.70.6):
     - glog
-  - react-native-helios (0.1.14):
+  - react-native-helios (0.1.15):
     - React
   - React-perflogger (0.70.6)
   - React-RCTActionSheet (0.70.6):
@@ -562,7 +562,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: b4a65947391c658450151275aa406f2b8263178f
   React-jsinspector: 60769e5a0a6d4b32294a2456077f59d0266f9a8b
   React-logger: 1623c216abaa88974afce404dc8f479406bbc3a0
-  react-native-helios: 7a611eb52f3f660cb63141beacff96d4318d9da3
+  react-native-helios: f328c3468fc68ef5329dac643e89afa4a4735eed
   React-perflogger: 8c79399b0500a30ee8152d0f9f11beae7fc36595
   React-RCTActionSheet: 7316773acabb374642b926c19aef1c115df5c466
   React-RCTAnimation: 5341e288375451297057391227f691d9b2326c3d

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1322,9 +1322,9 @@
     "@hapi/hoek" "^9.0.0"
 
 "@sideway/formula@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
-  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.1.tgz#80fcbcbaf7ce031e0ef2dd29b1bfc7c3f583611f"
+  integrity sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==
 
 "@sideway/pinpoint@^2.0.0":
   version "2.0.0"
@@ -1351,9 +1351,9 @@
     "@types/istanbul-lib-report" "*"
 
 "@types/node@*":
-  version "18.11.13"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.13.tgz#dff34f226ec1ac0432ae3b136ec5552bd3b9c0fe"
-  integrity sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w==
+  version "18.11.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.17.tgz#5c009e1d9c38f4a2a9d45c0b0c493fe6cdb4bcb5"
+  integrity sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==
 
 "@types/yargs-parser@*":
   version "21.0.0"
@@ -2315,9 +2315,9 @@ find-up@^5.0.0:
     path-exists "^4.0.0"
 
 flow-parser@0.*:
-  version "0.195.1"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.195.1.tgz#1f4017afd46c7873ed8dd9505f5fe5f00e08dd6c"
-  integrity sha512-8U3yQ8dny+CIsAjnH1QqpNw1mxLmqyp+0Mz/uh+YIH7srDkfabebwtFSnGv2m8yB2ZEPBrPwFYHe1kHKr/KQuw==
+  version "0.196.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.196.0.tgz#d62f85e02792fe625509a11343a8611ff976facd"
+  integrity sha512-739keKrDa+/5wpGFirMVK04elYMBjnwX2VH0WneKm3zx4K60ic8acJ6Ya6BekuHKLHIuz36ZUOQuGSUjc8D21A==
 
 flow-parser@^0.121.0:
   version "0.121.0"
@@ -2848,9 +2848,9 @@ json5@^0.5.1:
   integrity sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==
 
 json5@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
-  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.2.tgz#64471c5bdcc564c18f7c1d4df2e2297f2457c5ab"
+  integrity sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==
 
 jsonfile@^2.1.0:
   version "2.4.0"
@@ -3433,9 +3433,9 @@ node-int64@^0.4.0:
   integrity sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==
 
 node-releases@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.6.tgz#8a7088c63a55e493845683ebf3c828d8c51c5503"
-  integrity sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.8.tgz#0f349cdc8fcfa39a92ac0be9bc48b7706292b9ae"
+  integrity sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==
 
 node-stream-zip@^1.9.1:
   version "1.15.0"
@@ -3756,7 +3756,7 @@ react-native-gradle-plugin@^0.70.3:
   integrity sha512-oOanj84fJEXUg9FoEAQomA8ISG+DVIrTZ3qF7m69VQUJyOGYyDZmPqKcjvRku4KXlEH6hWO9i4ACLzNBh8gC0A==
 
 react-native-helios@../:
-  version "0.1.14"
+  version "0.1.15"
   dependencies:
     "@ethersproject/providers" "^5.7.2"
 

--- a/scripts/heliosup.ts
+++ b/scripts/heliosup.ts
@@ -6,7 +6,7 @@ import * as child_process from 'child_process';
 
 const rust_version = 'nightly';
 const name = 'helios';
-const helios_checksum = 'e132706f0b9866fa0b40b3edb698103699d67e64';
+const helios_checksum = 'aa838aeee199cc4d425e6dfc998fd97428e44779';
 const openssl_sys_checksum = 'b30313a9775ed861ce9456745952e3012e5602ea';
 const stdio = 'inherit';
 const build = path.resolve('build');
@@ -132,21 +132,14 @@ abstract class HeliosFactory {
     fs.writeFileSync(
       helios_toml,
       [
-        ...fs
-          .readFileSync(helios_toml, 'utf-8')
-          .split('\n')
-          .flatMap((str) => {
-            // HACK: Override to use a version of OpenSSL which is
-            //       compatible with the iOS Simulator.
-            if (str === '[patch.crates-io]')
-              return [str, `openssl-sys = { path = "${openssl_sys}" }`];
-
-            return [str];
-          }),
+        ...fs.readFileSync(helios_toml, 'utf-8').split('\n'),
         '',
         '[lib]',
         `name = "${name}"`,
         `crate-type = ["${this.getCrateType()}"]`,
+        '',
+        '[patch.crates-io]',
+        `openssl-sys = { path = "${openssl_sys}" }`,
       ].join('\n')
     );
 

--- a/scripts/heliosup.ts
+++ b/scripts/heliosup.ts
@@ -180,7 +180,7 @@ class AppleHeliosFactory extends HeliosFactory {
     super();
   }
   protected getTargets(): readonly string[] {
-    return ['aarch64-apple-ios', 'aarch64-apple-ios-sim'];
+    return ['aarch64-apple-ios-sim', 'aarch64-apple-ios'];
   }
   protected getCargoDependencies(): readonly string[] {
     return ['cargo-lipo'];

--- a/scripts/heliosup.ts
+++ b/scripts/heliosup.ts
@@ -9,7 +9,7 @@ const patch_crates_io = '[patch.crates-io]';
 
 const name = 'helios';
 const helios_checksum = 'aa838aeee199cc4d425e6dfc998fd97428e44779';
-const openssl_sys_checksum = 'b30313a9775ed861ce9456745952e3012e5602ea';
+const openssl_sys_checksum = 'd5037d4dcae4fcb5c301f9df907975033185a926';
 const stdio = 'inherit';
 const build = path.resolve('build');
 const ios = path.resolve('ios');
@@ -441,7 +441,6 @@ class AndroidHeliosFactory extends HeliosFactory {
             '',
             str,
             'rifgen = "0.1.61"',
-            'android_logger = { version = "0.11.1", default-features = false }',
             'jni-sys = "0.3.0"',
             'log = "0.4.6"',
             'log-panics = "2.0"',
@@ -549,12 +548,6 @@ class AndroidHeliosFactory extends HeliosFactory {
       '  #[generate_interface(constructor)]',
       '  pub fn new() -> Helios {',
       '    #[cfg(target_os = "android")]',
-      '    android_logger::init_once(',
-      '      android_logger::Config::default()',
-      '        .with_min_level(log::Level::Debug)',
-      '        .with_tag("cawfree"),',
-      '    );',
-      '    info!("init log system - done");',
       '    Helios {',
       '      client: None,',
       '      runtime: Runtime::new().unwrap(),',


### PR DESCRIPTION
Migrate the application to supporting [`helios@aa838aeee199cc4d425e6dfc998fd97428e44779`](https://github.com/a16z/helios/commit/aa838aeee199cc4d425e6dfc998fd97428e44779).
- For compatibility with `openssl-sys`, we needed to update to [`openssl-sys@d5037d4dcae4fcb5c301f9df907975033185a926`](https://github.com/sfackler/rust-openssl/commit/d5037d4dcae4fcb5c301f9df907975033185a926).
- This prevents the patch hack we use to enable execution on the iOS simulator from being ignored.